### PR TITLE
Fix logging issue and update deprecated sphinx API call

### DIFF
--- a/src/zundler/embed.py
+++ b/src/zundler/embed.py
@@ -18,17 +18,19 @@ Author: Adrian Vollmer
 import base64
 from fnmatch import fnmatch
 import json
-import logging
 import mimetypes
 import os
 from pathlib import Path
 import re
 import zlib
 
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
 try:
     import magic
 except ImportError as e:
-    logger = logging.getLogger(__name__)
     logger.error(str(e))
     logger.warning("Using `mimetypes` instead of `python-magic` for mime type guessing")
     magic = None
@@ -37,7 +39,7 @@ from zundler.args import __version__
 
 SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
 
-logger = logging.getLogger(__name__)
+
 
 
 def embed_assets(index_file, output_path=None, append_pre="", append_post=""):

--- a/src/zundler/sphinxext/__init__.py
+++ b/src/zundler/sphinxext/__init__.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from sphinx import version_info as sphinx_version_info
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.locale import get_translation
-from sphinx.util import logging, progress_message
+from sphinx.util import logging
+from sphinx.util.display import progress_message
 from sphinx.util.osutil import relpath
 
 


### PR DESCRIPTION
Hi @AdrianVollmer,

Thanks a lot for the great work; Zundler has proven very useful in our projects!

I just noticed two problems in the current version, which this PR solves:

1. Update the Sphinx API call `sphinx.util.progress_message` to `sphinx.util.display.progress_message`. The former is [deprecated](https://www.sphinx-doc.org/en/master/extdev/deprecated.html) since Sphinx 6.1 and is removed in Sphinx 8.0, making Zundler incompatible with Sphinx 8.
2. Use `sphinx.util.logging` instead of `logging` in `zundler.embed`. While `zundler.sphinxext.__init__` uses `sphinx.util.logging`, the `embed` module is using the standard library logging, causing logging messages to leak into system StdErr even when Sphinx is explicitly given one.

I just tested the changes locally and everything seems to be working fine.

I'd be grateful if you could release a new version with these changes as soon as possible.
Thanks a lot again.