### PR TITLE
Fix mimetype detection for resources embedded in css

### DIFF
--- a/src/zundler/embed.py
+++ b/src/zundler/embed.py
@@ -240,7 +240,7 @@ def embed_css_resources(css, filename):
             mime_type = "text/css"
             content = embed_css_resources(content, filename)
         else:
-            mime_type = get_mime_type(filename, content)
+            mime_type = get_mime_type(path, content)
         if not mime_type:
             logger.error("Unable to determine mime type: %s" % path)
             mime_type = "application/octet-stream"


### PR DESCRIPTION
Hi @AdrianVollmer,

thanks for the project, really appreciate the work!

I think I found a small issue in the mime type detection of resources that are embedded inside a css.

I have a project which contains some css that looks like this:

```css
:root {
    --image-caution: url("../_static/caution.svg");
}
```

When executing zundler to embedd everything into one html, I currently get this:
```css
:root {
    --image-caution: url("data:text/css;charset=utf-8;base64, ...");
}
```

You can see that the mime type is wrong, as it should be `image/svg+xml` instead of `text/css`.
Some debugging lead me to the conclusion that the issue is what you can see in my change.
The variable `filename` is being passed to the `get_mime_type` function, while it should be `path`, which contains the path to the resource whose mime type shall be detected.

BR
Valentin